### PR TITLE
gitignore: Revert wrong modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-backend/node_modules/
+node_modules/
 
 # I (BreadyX) would kindly like to include this to exclude my editor config file
 _vimrc_local.vim


### PR DESCRIPTION
Commit fad7e58 modified the `node_modules/` ignore rule into
`backend/node_modules/`, causing the `frontend/node_modules` to not be
ignored, as it should. Change back the rule as it was before the
aforementioned commit.